### PR TITLE
Improve suggestion fetching, caching, URL handling, and notifications

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -30,6 +30,23 @@ let isProPlusActive = false; // Initialize Pro+ mode as disabled
 let isGeminiActive = false; // Initialize Gemini AI mode as disabled
 let clientCache = {}; // Cache for suggestions
 let controller = null; // AbortController for fetch requests
+let inputDebounceTimeout = null;
+const SUGGESTION_DEBOUNCE_MS = 150;
+
+function clearSuggestions() {
+    suggestionsContainer.innerHTML = "";
+    suggestionsData = [];
+    activeIndex = -1;
+}
+
+function getSuggestionCacheKey(query) {
+    return query.trim().toLowerCase();
+}
+
+function areSuggestionsEqual(currentSuggestions, nextSuggestions) {
+    return currentSuggestions.length === nextSuggestions.length &&
+        currentSuggestions.every((suggestion, index) => suggestion === nextSuggestions[index]);
+}
 
 const engines = {
     web: {
@@ -92,6 +109,17 @@ const engines = {
     }
 };
 
+function syncEngineIconsFromMarkup() {
+    engineOptionButtons.forEach((button) => {
+        const engineKey = button.dataset.engine;
+        const icon = button.querySelector("svg");
+
+        if (engineKey && icon && engines[engineKey]) {
+            engines[engineKey].icon = icon.outerHTML;
+        }
+    });
+}
+
 // --- Engine Selector Behavior ---
 // When the container is clicked, toggle the "expanded" state and update placeholder
 engineSelectorContainer.addEventListener("click", (e) => {
@@ -153,35 +181,48 @@ function cycleSearchEngine() {
 
 // --- Suggestions & Search Functionality ---
 function fetchSuggestions(query) {
-    if (!query || query.trim() === "") {
-        suggestionsContainer.innerHTML = "";
-        suggestionsData = [];
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) {
+        clearSuggestions();
         return Promise.resolve([]);
     }
-    if (clientCache[query]) {
-        suggestionsData = clientCache[query];
-        renderSuggestions();
+
+    const cacheKey = getSuggestionCacheKey(trimmedQuery);
+    if (clientCache[cacheKey]) {
+        const cachedSuggestions = clientCache[cacheKey];
+        if (!areSuggestionsEqual(suggestionsData, cachedSuggestions)) {
+            suggestionsData = cachedSuggestions;
+            activeIndex = -1;
+            renderSuggestions();
+        }
         return Promise.resolve(suggestionsData);
     }
+
     if (controller) {
         controller.abort();
     }
     controller = new AbortController();
-    suggestionsContainer.innerHTML = "";
-    return fetch(`/api/suggestions?q=${encodeURIComponent(query)}`, {
+
+    return fetch(`/api/suggestions?q=${encodeURIComponent(trimmedQuery)}`, {
         signal: controller.signal,
         headers: { "X-Requested-With": "XMLHttpRequest" }
     })
         .then((response) => response.json())
         .then((data) => {
-            if (searchInput.value.trim() !== query) return [];
+            if (searchInput.value.trim() !== trimmedQuery) return suggestionsData;
             if (!searchInput.value.trim()) {
-                suggestionsContainer.innerHTML = "";
-                suggestionsData = [];
+                clearSuggestions();
                 return [];
             }
-            suggestionsData = Array.isArray(data) ? data : [];
-            clientCache[query] = suggestionsData;
+
+            const nextSuggestions = Array.isArray(data) ? data : [];
+            clientCache[cacheKey] = nextSuggestions;
+
+            if (areSuggestionsEqual(suggestionsData, nextSuggestions)) {
+                return suggestionsData;
+            }
+
+            suggestionsData = nextSuggestions;
             activeIndex = -1;
             renderSuggestions();
             return suggestionsData;
@@ -189,20 +230,22 @@ function fetchSuggestions(query) {
         .catch((error) => {
             if (error.name !== "AbortError") {
                 console.error("Error fetching suggestions:", error);
-                suggestionsData = [];
-                suggestionsContainer.innerHTML = "";
             }
-            return [];
+            return suggestionsData;
         });
 }
 
 function renderSuggestions() {
-    suggestionsContainer.innerHTML = "";
     if (!searchInput.value.trim()) {
-        suggestionsData = [];
+        clearSuggestions();
         return;
     }
-    if (!suggestionsData.length) return;
+
+    if (!suggestionsData.length) {
+        suggestionsContainer.replaceChildren();
+        return;
+    }
+
     const fragment = document.createDocumentFragment();
     suggestionsData.forEach((suggestion) => {
         const element = document.createElement("div");
@@ -215,19 +258,35 @@ function renderSuggestions() {
         };
         fragment.appendChild(element);
     });
-    suggestionsContainer.appendChild(fragment);
+    suggestionsContainer.replaceChildren(fragment);
 }
 
 function handleInput() {
     const query = searchInput.value.trim();
+
+    if (inputDebounceTimeout) {
+        clearTimeout(inputDebounceTimeout);
+        inputDebounceTimeout = null;
+    }
+
     if (!query) {
-        suggestionsContainer.innerHTML = "";
-        suggestionsData = [];
+        if (controller) {
+            controller.abort();
+        }
+        clearSuggestions();
         return;
     }
-    window.requestAnimationFrame(() => {
+
+    const cacheKey = getSuggestionCacheKey(query);
+    if (clientCache[cacheKey] && !areSuggestionsEqual(suggestionsData, clientCache[cacheKey])) {
+        suggestionsData = clientCache[cacheKey];
+        activeIndex = -1;
+        renderSuggestions();
+    }
+
+    inputDebounceTimeout = setTimeout(() => {
         fetchSuggestions(query);
-    });
+    }, SUGGESTION_DEBOUNCE_MS);
 }
 
 function updateActiveSuggestion() {
@@ -243,8 +302,50 @@ function updateActiveSuggestion() {
     });
 }
 
+function getNavigableUrl(input) {
+    const candidate = input.trim();
+
+    if (!candidate || candidate.startsWith("!") || /\s/.test(candidate)) {
+        return null;
+    }
+
+    const firstColon = candidate.indexOf(":");
+    const firstDot = candidate.indexOf(".");
+    const hasSchemeLikePrefix = firstColon > -1 && (firstDot === -1 || firstColon < firstDot);
+    const hasProtocol = /^[a-z][a-z0-9+.-]*:\/\//i.test(candidate);
+    const hasLocalhost = /^localhost(?::\d+)?(?:[/?#]|$)/i.test(candidate);
+    const hasIPv4 = /^(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?(?:[/?#]|$)/.test(candidate);
+    const hasDomainDot = /^(?:www\.)?[^/?#.]+\.[^/?#]+(?:[/?#]|$)/i.test(candidate);
+
+    if (hasSchemeLikePrefix && !hasProtocol && !hasLocalhost) {
+        return null;
+    }
+
+    if (!hasProtocol && !hasLocalhost && !hasIPv4 && !hasDomainDot) {
+        return null;
+    }
+
+    try {
+        const url = new URL(hasProtocol ? candidate : `https://${candidate}`);
+
+        if (!["http:", "https:"].includes(url.protocol)) {
+            return null;
+        }
+
+        return url.href;
+    } catch {
+        return null;
+    }
+}
+
 function performSearch(query) {
     if (!query) return;
+
+    const navigableUrl = getNavigableUrl(query);
+    if (navigableUrl) {
+        window.location.href = navigableUrl;
+        return;
+    }
 
     // Check if Gemini AI mode is active
     if (isGeminiActive) {
@@ -273,20 +374,9 @@ function performSearch(query) {
     if (currentEngine !== "web" && !query.startsWith("!")) {
         query = engines[currentEngine].bang + query;
     }
-    const isURLLike = query.includes(".") && !query.startsWith("!");
-    // A more robust URL test pattern:
-    const domainPattern =
-        /^(www\.)?[a-zA-Z0-9][-a-zA-Z0-9@:%._+~#=]{0,256}\.[a-zA-Z0-9()]{1,}(\.[a-zA-Z0-9()]{1,})*$/i;
-    if (isURLLike && domainPattern.test(query)) {
-        const url =
-            query.startsWith("http://") || query.startsWith("https://")
-                ? query
-                : "https://" + query;
-        window.location.href = url;
-    } else {
-        // Use DuckDuckGo (unduck) for normal web searches when Pro+ is not active
-        window.location.href = `https://unduck.link?q=${encodeURIComponent(query)}`;
-    }
+
+    // Use DuckDuckGo (unduck) for normal web searches when Pro+ is not active
+    window.location.href = `https://unduck.link?q=${encodeURIComponent(query)}`;
 }
 
 // --- Event Listeners ---
@@ -315,8 +405,7 @@ searchInput.addEventListener("keydown", (e) => {
         updateActiveSuggestion();
     } else if (e.key === "Escape") {
         e.preventDefault();
-        suggestionsContainer.innerHTML = "";
-        suggestionsData = [];
+        clearSuggestions();
     }
 });
 
@@ -329,8 +418,7 @@ document.addEventListener("click", (e) => {
         !searchInput.contains(e.target) &&
         !suggestionsContainer.contains(e.target)
     ) {
-        suggestionsContainer.innerHTML = "";
-        suggestionsData = [];
+        clearSuggestions();
     }
 });
 
@@ -479,16 +567,14 @@ function updatePoweredByText() {
     }
 }
 
-function showGeminiNotification() {
-    // Remove any existing notification
-    const existingNotification = document.getElementById('gemini-notification');
+function showModeNotification(id, message) {
+    const existingNotification = document.getElementById(id);
     if (existingNotification) {
         existingNotification.remove();
     }
 
-    // Create notification element
     const notification = document.createElement('div');
-    notification.id = 'gemini-notification';
+    notification.id = id;
     notification.style.cssText = `
         position: fixed;
         top: 20px;
@@ -507,21 +593,15 @@ function showGeminiNotification() {
         opacity: 0;
         transition: all 0.3s ease-in-out;
     `;
-    
-    notification.textContent = isGeminiActive ? 
-        '🤖 AI Mode ENABLED - Using Gemini Search' : 
-        '🤖 AI Mode DISABLED - Using Standard Search';
+    notification.textContent = message;
 
-    // Add to page
     document.body.appendChild(notification);
 
-    // Animate in
     setTimeout(() => {
         notification.style.opacity = '1';
         notification.style.transform = 'translateX(-50%) translateY(0)';
     }, 10);
 
-    // Remove after 3 seconds
     setTimeout(() => {
         notification.style.opacity = '0';
         notification.style.transform = 'translateX(-50%) translateY(-20px)';
@@ -533,12 +613,22 @@ function showGeminiNotification() {
     }, 3000);
 }
 
+function showGeminiNotification() {
+    showModeNotification(
+        'gemini-notification',
+        isGeminiActive
+            ? '🤖 AI Mode ENABLED - Using Gemini Search'
+            : '🤖 AI Mode DISABLED - Using Standard Search'
+    );
+}
+
 // ---------------------------------------------
 // 4) Show the initial engine on page‐load
 // ---------------------------------------------
 window.addEventListener("load", () => {
     searchInput.setAttribute("autocomplete", "off");
     searchInput.focus();
+    syncEngineIconsFromMarkup();
     updateEngineIcon();
 
     // Remove any existing selected-engine-display element
@@ -564,7 +654,7 @@ window.addEventListener("load", () => {
                 .then((response) => response.json())
                 .then((data) => {
                     if (Array.isArray(data)) {
-                        clientCache[term] = data;
+                        clientCache[getSuggestionCacheKey(term)] = data;
                     }
                 })
                 .catch(() => {});
@@ -621,57 +711,12 @@ function updateProPlusState() {
 }
 
 function showProPlusNotification() {
-    // Remove any existing notification
-    const existingNotification = document.getElementById('pro-plus-notification');
-    if (existingNotification) {
-        existingNotification.remove();
-    }
-
-    // Create notification element
-    const notification = document.createElement('div');
-    notification.id = 'pro-plus-notification';
-    notification.style.cssText = `
-        position: fixed;
-        top: 20px;
-        left: 50%;
-        transform: translateX(-50%);
-        background: rgba(13, 25, 45, 0.95);
-        color: #60a5fa;
-        padding: 16px 24px;
-        border-radius: 8px;
-        box-shadow: 0 0 20px rgba(59, 130, 246, 0.4);
-        z-index: 10000;
-        font-weight: 600;
-        font-size: 16px;
-        backdrop-filter: blur(10px);
-        font-family: 'Space Grotesk', sans-serif;
-        opacity: 0;
-        transition: all 0.3s ease-in-out;
-    `;
-    
-    notification.textContent = isProPlusActive ?
-        'Pro Mode ENABLED - Using Kagi Search' :
-        'Pro Mode DISABLED - Using Unduck Search';
-
-    // Add to page
-    document.body.appendChild(notification);
-
-    // Animate in
-    setTimeout(() => {
-        notification.style.opacity = '1';
-        notification.style.transform = 'translateX(-50%) translateY(0)';
-    }, 10);
-
-    // Remove after 3 seconds
-    setTimeout(() => {
-        notification.style.opacity = '0';
-        notification.style.transform = 'translateX(-50%) translateY(-20px)';
-        setTimeout(() => {
-            if (notification.parentNode) {
-                notification.remove();
-            }
-        }, 300);
-    }, 3000);
+    showModeNotification(
+        'pro-plus-notification',
+        isProPlusActive
+            ? 'Pro Mode ENABLED - Using Kagi Search'
+            : 'Pro Mode DISABLED - Using Unduck Search'
+    );
 }
 
 // Initial state update
@@ -679,12 +724,6 @@ document.addEventListener('DOMContentLoaded', () => {
     updateProPlusState();
     updateGeminiState();
     populateMobileModalIcons(); // Populate mobile modal with correct SVGs
-});
-
-// Add input event listener for search suggestions
-searchInput.addEventListener('input', function(e) {
-  const query = e.target.value.trim();
-  fetchSuggestions(query);
 });
 
 // --- Mobile Circular Engine Selector Functions ---


### PR DESCRIPTION
### Motivation
- Reduce redundant network requests and DOM thrash for suggestions by adding debouncing and better caching with normalized keys.
- Make search navigation more robust by detecting direct URL-like inputs and short-circuiting to navigation instead of treating them as queries.
- Unify transient on-screen notifications used for toggling modes to remove duplicated code and simplify UI feedback.
- Ensure SVG engine icons in markup are synced into the runtime `engines` map for consistent icon usage across desktop/mobile selectors.

### Description
- Added helper functions `clearSuggestions`, `getSuggestionCacheKey`, and `areSuggestionsEqual` and a debounce timer with `SUGGESTION_DEBOUNCE_MS` to reduce unnecessary suggestion fetches and re-renders.
- Normalized suggestion caching to use trimmed/lowercased keys, reused cached suggestions when available, and avoided re-rendering identical suggestion lists; fetches now use the trimmed query and respect an `AbortController` to cancel stale requests.
- Reworked suggestion rendering to use `DocumentFragment` and `replaceChildren` and updated `handleInput` to debounce calls and pre-populate from cache when possible.
- Introduced `getNavigableUrl` to detect safe navigable URLs and updated `performSearch` to navigate directly for URL-like inputs, and to prefer engine `customUrl`, Pro+ Kagi behavior, or Gemini mode as before; old ad-hoc domain regex logic was removed.
- Added `syncEngineIconsFromMarkup` to read SVGs from `.engine-option` buttons into the `engines` table and call it on `window.load`; prefetch of suggestion seeds now stores using the normalized cache key.
- Consolidated notification logic into `showModeNotification(id, message)` and replaced duplicated notification implementations with calls to this helper for both Gemini and Pro+ notifications.
- Minor compatibility changes: left an empty `showSelectedEngineName` stub, ensured `populateMobileModalIcons()` is invoked on DOMContentLoaded, and preserved existing keyboard and engine selection behavior.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a345266924083319b65d5e4bbbcc688)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Debounce suggestion fetching and normalize cache keys in script.js
> - Input handling in `handleInput` is now debounced by 150ms via `SUGGESTION_DEBOUNCE_MS`, reducing redundant fetches during fast typing.
> - Suggestion cache keys are normalized (trimmed and lowercased) via `getSuggestionCacheKey`, fixing prefetched suggestions being unretrievable by differently-cased queries.
> - `fetchSuggestions` retains existing suggestions on error instead of clearing them, and skips re-rendering when results are unchanged (via `areSuggestionsEqual`).
> - `renderSuggestions` now uses `replaceChildren` instead of `innerHTML` clearing and `appendChild`.
> - Behavioral Change: in-flight requests are aborted immediately when input is cleared, and cached suggestions are rendered synchronously before a fetch completes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3098f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->